### PR TITLE
Improve loading process

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 > A Vue.js component for dynamically loading the Microsoft UHF
 
 # Usage
+
 ## Install the component
 
 ``npm i -s vue-uhf``
@@ -11,7 +12,7 @@
 ```html
 <template>
     <div class="page">
-        <UHF partnerID="YourPartnerID" headerID="YourHeaderID" footerID="YourFooterID" :cookieCompliance="true" />
+        <UHF partner-id="YourPartnerId" header-id="YourHeaderId" footer-id="YourFooterId" :cookieCompliance="true" />
     </div>
 </template>
 
@@ -36,7 +37,7 @@ Microsoft accessibility standards require that keyboard users be able to skip ov
 </div>
 ```
 
-## Configure header/footer placement
+## Configure header/footer placement (optional)
 
 By default the header will be prepended and the footer will be appended to the `<body>`-tag. Set `headerContainerId` and `footerContainerId` to place the markup within specific containers of your layout.
 
@@ -56,8 +57,6 @@ Suggested layout:
     </div>
 </template>
 ```
-
-[Layout example](https://gist.github.com/sonjastrieder/c9ea2f184bcf273cb4fa91440c36be8d)
 
 ## Browser support
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,43 @@ export default {
 </script>
 ```
 
+## Configure "Skip to main content" link
+
+Microsoft accessibility standards require that keyboard users be able to skip over header and navigation elements and go straight to the main area of any page. By default the main content ID is set to `mainContent`.
+
+```html
+<div id="mainContent">
+    <!-- App content here -->
+</div>
+```
+
+## Configure header/footer placement
+
+By default the header will be prepended and the footer will be appended to the `<body>`-tag. Set `headerContainerId` and `footerContainerId` to place the markup within specific containers of your layout.
+
+Suggested layout:
+
+```html
+<!-- App.vue -->
+
+<template>
+    <div>
+        <UHF header-container-id="headerContent" footer-container-id="footerContent" />
+        <header id="headerContent"></header>
+        <main id="mainContent">
+            <router-view />
+        </main>
+        <footer id="footerContent"></footer>
+    </div>
+</template>
+```
+
+[Layout example](https://gist.github.com/sonjastrieder/c9ea2f184bcf273cb4fa91440c36be8d)
+
+## Browser support
+
+If support for legacy browsers like IE11 is required please ensure to explicitly transpile this dependency with Babel. See [transpileDependencies](https://cli.vuejs.org/config/#transpiledependencies)
+
 # Changelog
 
 ## 1.0.4

--- a/uhf.vue
+++ b/uhf.vue
@@ -1,72 +1,168 @@
 <script>
-	import axios from 'axios';
-	import JQuery from 'jquery';
-	window.$ = window.jQuery = JQuery;
+import axios from "axios";
 
-	export default {
-		props: {
-			partnerID: {
-				type: String,
-				default: 'UHFPortal'
-			},
-			headerID: {
-				type: String,
-				default: 'UHFPortalHeader'
-			},
-			footerID: {
-				type: String,
-				default: 'UHFPortalFooter'
-			},
-			cookieCompliance: {
-				type: Boolean,
-				default: false
-			}
-		},
-		render() {
-			return this.$slots.default;
-		},
-		created() {
-			axios.get(`https://uhf.microsoft.com/en-us/shell/xml/${this.partnerID}?headerid=${this.headerID}&footerid=${this.footerID}&CookieComplianceEnabled=${this.cookieCompliance}`)
-				.then(response => {
-					let xmlParser = new DOMParser();
-					let xmlData = xmlParser.parseFromString(response.data, 'application/xml');
-					let cssIncludes = xmlData.querySelector('cssIncludes').textContent;
-					let javascriptIncludes = xmlData.querySelector('javascriptIncludes').textContent;
-					let headerHtml = xmlData.querySelector('headerHtml').textContent;
-					let footerHtml = xmlData.querySelector('footerHtml').textContent;
+export default {
+    props: {
+        // UHF options
+        partnerId: {
+            type: String,
+            default: "UHFPortal",
+        },
+        headerId: {
+            type: String,
+            default: "UHFPortalHeader",
+        },
+        footerId: {
+            type: String,
+            default: "UHFPortalFooter",
+        },
+        cookieCompliance: {
+            type: Boolean,
+            default: false,
+        },
+        trackingId: {
+            type: String,
+            default: "",
+        },
 
-					// Add CSS
-					document.querySelector('head').insertAdjacentHTML('beforeend', cssIncludes);
+        // Loading options
+        headerContainerId: {
+            type: String,
+            default: null,
+        },
+        footerContainerId: {
+            type: String,
+            default: null,
+        },
+        includeJQuery: {
+            type: Boolean,
+            default: true,
+        },
+    },
+    data() {
+        return {
+            uhfElements: [], // all DOM elements to be removed on beforeDestroy
+        };
+    },
+    mounted() {
+        const { uhfElements } = this;
+        const body = document.body;
 
-					// Add header and footer
-					document.querySelector('body').insertAdjacentHTML('afterbegin', headerHtml);
-					document.querySelector('body').insertAdjacentHTML('beforeend', footerHtml);
+        Promise.all([
+            axios.get(
+                `https://uhf.microsoft.com/en-us/shell/xml/${this.partnerId}?headerid=${this.headerId}&footerid=${this.footerId}&CookieComplianceEnabled=${this.cookieCompliance}&Tracking=${this.trackingId}`
+            ),
+            this.includeJQuery
+                ? this.loadingScriptByUrl("https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js")
+                : null,
+        ])
+            .then((responses) => {
+                // jQuery and UHF data loaded:
 
-					// Cache header and footer
-					this.uhfElements = document.querySelectorAll('.uhf');
+                const xmlParser = new DOMParser();
+                const xmlData = xmlParser.parseFromString(responses[0].data, "application/xml");
 
-					// Hide header and footer
-					this.uhfElements[0].style.display = 'none';
-					this.uhfElements[1].style.display = 'none';
+                // Load stylesheets
 
-					this.uhfElements[0].classList.add('vue-uhf-added');
-					this.uhfElements[1].classList.add('vue-uhf-added');
+                const cssIncludes = xmlData.querySelector("cssIncludes").textContent;
+                const divStyles = document.createElement("div");
+                divStyles.classList.add("uhf-includes");
+                divStyles.innerHTML = cssIncludes;
+                uhfElements.push(divStyles);
 
-					setTimeout(() => {
-						// Show header and footer
-						this.uhfElements[0].style.display = 'block';
-						this.uhfElements[1].style.display = 'block';
+                const promises = Promise.all([
+                    Promise.resolve(xmlData),
+                    ...[...divStyles.querySelectorAll("link")].map((el) => this.loading(el)),
+                ]);
 
-						// Add JS
-						let range = document.createRange();
-						range.setStart(document.querySelector('body'), 0);
-						document.querySelector('body').appendChild(range.createContextualFragment(javascriptIncludes));
-					}, 500);
-				});
-		},
-		beforeDestroy() {
-			this.uhfElements[0].remove();
-			this.uhfElements[1].remove();
-		}
-	}
+                body.appendChild(divStyles);
+
+                return promises;
+            })
+            .then(([xmlData]) => {
+                // Stylesheets loaded:
+                // Add header/footer markup to page
+
+                const headerHtml = xmlData.querySelector("headerHtml").textContent;
+                const footerHtml = xmlData.querySelector("footerHtml").textContent;
+                const headerContainer = document.getElementById(this.headerContainerId || "") || body;
+                const footerContainer = document.getElementById(this.footerContainerId || "") || body;
+
+                headerContainer.insertAdjacentHTML("afterbegin", headerHtml);
+                footerContainer.insertAdjacentHTML("beforeend", footerHtml);
+
+                uhfElements.push(...document.querySelectorAll(".uhf"));
+
+                // Load JavaScript
+
+                const jsIncludes = xmlData.querySelector("javascriptIncludes").textContent;
+                const divScripts = document.createElement("div");
+                divScripts.classList.add("uhf-includes");
+
+                const range = document.createRange();
+                range.setStart(divScripts, 0);
+                divScripts.appendChild(range.createContextualFragment(jsIncludes));
+                uhfElements.push(divScripts);
+
+                const promises = Promise.all(
+                    [...divScripts.querySelectorAll("script")].map((el) => this.loading(el))
+                );
+
+                body.appendChild(divScripts);
+
+                return promises;
+            })
+            .then(() => {
+                // JavaScript loaded:
+
+                this.$emit("ready");
+            })
+            .catch((error) => {
+                this.$emit("error", error);
+            });
+    },
+    beforeDestroy() {
+        this.uhfElements.forEach((el) => {
+            el.remove();
+        });
+
+        this.uhfElements = [];
+    },
+    methods: {
+        loading(el) {
+            return new Promise((resolve, reject) => {
+                el.onload = function () {
+                    resolve(el);
+                };
+
+                el.onerror = function () {
+                    reject(new Error(`Failed to load ${el}`));
+                };
+            });
+        },
+        loadingScriptByUrl(url) {
+            return new Promise((resolve, reject) => {
+                const element = document.createElement("script");
+                const parent = "body";
+                const attr = "src";
+
+                element.onload = function () {
+                    resolve(url);
+                };
+
+                element.onerror = function () {
+                    reject(url);
+                };
+
+                element.async = true;
+                element[attr] = url;
+                this.uhfElements.push(element);
+                document[parent].appendChild(element);
+            });
+        },
+    },
+    render() {
+        return this.$slots.default;
+    },
+};
 </script>


### PR DESCRIPTION
### Updates

1. Use promises to define loading order to prevent content flashing if the stylesheet doesn't load within the original timeout of 500ms
   a. Load UHF data and jQuery
   b. When ready load stylesheets
   c. When ready add header/footer markup to the page
   d. When ready load script files
   e. When ready emit 'ready' event
2. Allow for header/footer to be placed into specific containers by setting the container id via `headerContainerId` and `footerContainerId`
3. Add `targetingID` option
4. In addition to removing the header and footer markup from the page on `beforeDestroy` remove css and js includes
5. Load jQuery from CDN, with the option to disable the jQuery include via `includeJQuery` if the project already includes jQuery
6. Update readme with information about
   - 'Skip to main content' link
   - Header/footer markup placement
   - Browser support

### Breaking changes

1. Class `.vue-uhf-added` doesn't get added any more as the markup only gets added when the stylesheet is loaded. 
2. Props name change for `partnerId`, `headerId` and `footerId` (original names `partnerID`, `headerID`, `footerID` translate to `partner-i-d` when set on component)